### PR TITLE
Bump version to v0.15.47

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: work-spaces/install-spaces@v0.15.45
+    - uses: work-spaces/install-spaces@v0.15.47
 
     - id: create-workspace
       run: |


### PR DESCRIPTION
Automated version bump: replace `install-spaces@v\d+\.\d+\.\d+[\w.+-]*` with `install-spaces@v0.15.47` in `action.yml`.